### PR TITLE
respect blocks for timed-roller-shutters

### DIFF
--- a/backend/src/main/java/ch/akop/homesystem/services/impl/RollerShutterService.java
+++ b/backend/src/main/java/ch/akop/homesystem/services/impl/RollerShutterService.java
@@ -342,8 +342,10 @@ public class RollerShutterService extends Activatable {
         .flatMap(name -> deviceService.findDeviceByName(name, RollerShutter.class).stream())
         .forEach(rollerShutter -> {
           if (rollerShutter.getConfig().getCloseAt() != null && rollerShutter.getConfig().getCloseAt().equals(time)) {
-            rollerShutter.close("time").subscribe();
-          } else {
+            if (isOkToClose(rollerShutter)) {
+              rollerShutter.close("time").subscribe();
+            }
+          } else if (isOkToOpen(rollerShutter)) {
             rollerShutter.open("time").subscribe();
           }
         });


### PR DESCRIPTION
There was a bug, that when a rollerShutter was blocked, the time-feature doesn't respect the block. The time-feature respected nothing except the time.